### PR TITLE
test: +rappels/edit, validations, et intégration CLI (coverage 95%)

### DIFF
--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from datetime import date
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SRC_DIR = os.path.join(PROJECT_ROOT, 'src')
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+import task_manager as tm  # noqa: E402
+
+
+class TestCLIIntegration(unittest.TestCase):
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(delete=False)
+        self.tmpfile.close()
+        tm.TASKS_FILE = self.tmpfile.name
+
+    def tearDown(self):
+        try:
+            os.remove(self.tmpfile.name)
+        except OSError:
+            pass
+
+    def run_cli(self, argv):
+        saved_argv = sys.argv
+        sys.argv = ['prog'] + argv
+        buf = StringIO()
+        try:
+            with redirect_stdout(buf):
+                tm.main()
+        finally:
+            sys.argv = saved_argv
+        return buf.getvalue()
+
+    def test_full_cli_flow_add_list_delete(self):
+        today = date.today().strftime("%Y-%m-%d")
+
+        # add
+        out = self.run_cli([
+            'add', '--title', 'T', '--desc', 'D', '--priority', '1', '--due', today
+        ])
+        self.assertIn("Tâche ajoutée", out)
+
+        # list (priority)
+        out = self.run_cli(['list', '--sort', 'priority'])
+        self.assertIn("[1] T (Priorité: 1 – Due: " + today + ")", out)
+
+        # edit
+        out = self.run_cli(['edit', '--id', '1', '--priority', '2'])
+        self.assertIn("mise à jour", out)
+
+        # delete
+        out = self.run_cli(['delete', '--id', '1'])
+        self.assertIn("Tâche 1 supprimée", out)
+
+        # list vide
+        out = self.run_cli(['list'])
+        self.assertIn("Aucune tâche à afficher.", out)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_reminders_and_edit.py
+++ b/tests/test_reminders_and_edit.py
@@ -1,0 +1,103 @@
+import os
+import sys
+import json
+import tempfile
+import unittest
+from io import StringIO
+from datetime import date, timedelta
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SRC_DIR = os.path.join(PROJECT_ROOT, 'src')
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+import task_manager as tm  # noqa: E402
+
+
+class TestRemindersAndEdit(unittest.TestCase):
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(delete=False)
+        self.tmpfile.close()
+        tm.TASKS_FILE = self.tmpfile.name
+
+    def tearDown(self):
+        try:
+            os.remove(self.tmpfile.name)
+        except OSError:
+            pass
+
+    def d(self, delta_days: int) -> str:
+        return (date.today() + timedelta(days=delta_days)).strftime("%Y-%m-%d")
+
+    def test_edit_task_updates_selected_fields(self):
+        tasks = [{
+            'id': 1, 'title': 'A', 'desc': 'x', 'priority': 3,
+            'due': self.d(5), 'created': ''
+        }]
+        with open(self.tmpfile.name, 'w', encoding='utf-8') as f:
+            json.dump(tasks, f)
+
+        class Args: pass
+        args = Args()
+        args.id = 1
+        args.title = "B"
+        args.desc = None
+        args.priority = 1
+        args.due = self.d(7)
+        tm.edit_task(args)
+
+        with open(self.tmpfile.name, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        t = data[0]
+        self.assertEqual(t['title'], "B")
+        self.assertEqual(t['priority'], 1)
+        self.assertEqual(t['due'], self.d(7))
+        self.assertEqual(t['desc'], 'x')
+
+    def test_list_overdue_filter(self):
+        tasks = [
+            {'id': 1, 'title': 'old',  'desc': '', 'priority': 2, 'due': self.d(-1), 'created': ''},
+            {'id': 2, 'title': 'soon', 'desc': '', 'priority': 2, 'due': self.d(2),  'created': ''},
+        ]
+        with open(self.tmpfile.name, 'w', encoding='utf-8') as f:
+            json.dump(tasks, f)
+
+        class Args: pass
+        args = Args()
+        args.sort = 'date'
+        args.overdue = True
+        args.due_in = None
+
+        saved = sys.stdout; out = StringIO(); sys.stdout = out
+        tm.list_tasks(args)
+        sys.stdout = saved
+
+        output = out.getvalue()
+        self.assertIn("[1]", output)
+        self.assertNotIn("[2]", output)
+
+    def test_list_due_in_filter(self):
+        tasks = [
+            {'id': 1, 'title': 'far',  'desc': '', 'priority': 2, 'due': self.d(5), 'created': ''},
+            {'id': 2, 'title': 'near', 'desc': '', 'priority': 2, 'due': self.d(2), 'created': ''},
+        ]
+        with open(self.tmpfile.name, 'w', encoding='utf-8') as f:
+            json.dump(tasks, f)
+
+        class Args: pass
+        args = Args()
+        args.sort = 'date'
+        args.overdue = False
+        args.due_in = 3
+
+        saved = sys.stdout; out = StringIO(); sys.stdout = out
+        tm.list_tasks(args)
+        sys.stdout = saved
+
+        output = out.getvalue()
+        self.assertIn("[2]", output)
+        self.assertNotIn("[1]", output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_validations_and_errors.py
+++ b/tests/test_validations_and_errors.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import json
+import tempfile
+import unittest
+from io import StringIO
+from datetime import date, timedelta
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SRC_DIR = os.path.join(PROJECT_ROOT, 'src')
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+import task_manager as tm  # noqa: E402
+
+
+class TestValidationsAndErrors(unittest.TestCase):
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(delete=False)
+        self.tmpfile.close()
+        tm.TASKS_FILE = self.tmpfile.name
+
+    def tearDown(self):
+        try:
+            os.remove(self.tmpfile.name)
+        except OSError:
+            pass
+
+    def test_validate_priority_raises(self):
+        with self.assertRaises(ValueError):
+            tm.validate_priority(0)
+        with self.assertRaises(ValueError):
+            tm.validate_priority(6)
+
+    def test_validate_due_raises(self):
+        with self.assertRaises(ValueError):
+            tm.validate_due("20-01-2025")
+        with self.assertRaises(ValueError):
+            tm.validate_due("not-a-date")
+
+    def test_delete_nonexistent_id_message(self):
+        with open(self.tmpfile.name, 'w', encoding='utf-8') as f:
+            json.dump([{'id': 1, 'title': 'A', 'desc': '', 'priority': 1,
+                        'due': date.today().strftime("%Y-%m-%d"), 'created': ''}], f)
+
+        class Args: pass
+        args = Args(); args.id = 999
+
+        saved = sys.stdout; out = StringIO(); sys.stdout = out
+        tm.delete_task(args)
+        sys.stdout = saved
+
+        self.assertIn("Aucune tâche trouvée", out.getvalue())
+
+    def test_edit_nonexistent_id_message(self):
+        with open(self.tmpfile.name, 'w', encoding='utf-8') as f:
+            json.dump([], f)
+
+        class Args: pass
+        args = Args(); args.id = 1; args.title = "X"; args.desc = None
+        args.priority = None; args.due = None
+
+        saved = sys.stdout; out = StringIO(); sys.stdout = out
+        tm.edit_task(args)
+        sys.stdout = saved
+
+        self.assertIn("Aucune tâche trouvée", out.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ajout de tests/test_reminders_and_edit.py, tests/test_validations_and_errors.py, tests/test_cli_integration.py. Couvre edit, filtres --overdue/--due-in, validations, messages d’erreur et la CLI (main() + argparse). Objectif : coverage ≥ 95%.